### PR TITLE
Handle USB CLEAR_FEATURE

### DIFF
--- a/src/usb/cdc_acm.c
+++ b/src/usb/cdc_acm.c
@@ -78,7 +78,11 @@ bool_t cdc_acm_handle_class_request(void)
     }
 
     case CDC_SET_CONTROL_LINE_STATE:
-        /* wValue = DTR/RTS. We ignore them and return success. */
+        /* wValue[0]: D0=DTR, D1=RTS.
+         * When DTR drops the host has closed the port. Reset comms
+         * so we are in a clean state when it is reopened. */
+        if (!(req->wValue & 1))
+            usb_cdc_acm_ops.configure();
         break;
 
     case CDC_SEND_BREAK:

--- a/src/usb/core.c
+++ b/src/usb/core.c
@@ -97,7 +97,7 @@ static bool_t handle_control_request(void)
 
         /* CLEAR_FEATURE(ENDPOINT_HALT): Required by USB spec.
          * Reset data toggle and double-buffer ring state. */
-        usb_clear_halt(req->wIndex);
+        usb_clear_stall(req->wIndex);
 
     } else if ((req->bmRequestType&0x7f) == 0x21) {
 
@@ -149,6 +149,12 @@ static void usb_write_ep0(void)
     }
 }
 
+static void usb_ctrl_stall(void)
+{
+    usb_stall(0x00);
+    usb_stall(0x80);
+}
+
 void handle_rx_ep0(bool_t is_setup)
 {
     bool_t ready = FALSE;
@@ -165,7 +171,7 @@ void handle_rx_ep0(bool_t is_setup)
     } else if (ep0.data_len < 0) {
 
         /* Unexpected Transaction */
-        usb_stall(0);
+        usb_ctrl_stall();
         usb_read(ep, NULL, 0);
 
     } else if (ep0_data_out()) {
@@ -199,7 +205,7 @@ void handle_rx_ep0(bool_t is_setup)
     if (!handle_control_request()) {
 
         /* Unhandled Control Transfer: STALL */
-        usb_stall(0);
+        usb_ctrl_stall();
         ep0.data_len = -1; /* Complete */
 
     } else if (ep0_data_in()) {

--- a/src/usb/core.c
+++ b/src/usb/core.c
@@ -91,6 +91,14 @@ static bool_t handle_control_request(void)
 
         handled = cdc_acm_set_configuration();
 
+    } else if ((req->bmRequestType == 0x02)
+               && (req->bRequest == CLEAR_FEATURE)
+               && (req->wValue == 0x0000)) {
+
+        /* CLEAR_FEATURE(ENDPOINT_HALT): Required by USB spec.
+         * Reset data toggle and double-buffer ring state. */
+        usb_clear_halt(req->wIndex);
+
     } else if ((req->bmRequestType&0x7f) == 0x21) {
 
         handled = cdc_acm_handle_class_request();

--- a/src/usb/defs.h
+++ b/src/usb/defs.h
@@ -78,8 +78,8 @@ void handle_tx_ep0(void);
 /* USB Hardware */
 enum { EPT_CONTROL=0, EPT_ISO, EPT_BULK, EPT_INTERRUPT, EPT_DBLBUF };
 void usb_configure_ep(uint8_t ep, uint8_t type, uint32_t size);
-void usb_stall(uint8_t ep);
-void usb_clear_halt(uint8_t ep);
+void usb_stall(uint8_t epnr);
+void usb_clear_stall(uint8_t epnr);
 void usb_setaddr(uint8_t addr);
 void hw_usb_init(void);
 void hw_usb_deinit(void);
@@ -101,7 +101,7 @@ struct usb_driver {
     void (*read)(uint8_t epnr, void *buf, uint32_t len);
     void (*write)(uint8_t epnr, const void *buf, uint32_t len);
     void (*stall)(uint8_t epnr);
-    void (*clear_halt)(uint8_t epnr);
+    void (*clear_stall)(uint8_t epnr);
 };
 
 extern const struct usb_driver dwc_otg;

--- a/src/usb/defs.h
+++ b/src/usb/defs.h
@@ -79,6 +79,7 @@ void handle_tx_ep0(void);
 enum { EPT_CONTROL=0, EPT_ISO, EPT_BULK, EPT_INTERRUPT, EPT_DBLBUF };
 void usb_configure_ep(uint8_t ep, uint8_t type, uint32_t size);
 void usb_stall(uint8_t ep);
+void usb_clear_halt(uint8_t ep);
 void usb_setaddr(uint8_t addr);
 void hw_usb_init(void);
 void hw_usb_deinit(void);
@@ -100,6 +101,7 @@ struct usb_driver {
     void (*read)(uint8_t epnr, void *buf, uint32_t len);
     void (*write)(uint8_t epnr, const void *buf, uint32_t len);
     void (*stall)(uint8_t epnr);
+    void (*clear_halt)(uint8_t epnr);
 };
 
 extern const struct usb_driver dwc_otg;

--- a/src/usb/hw_at32f4.c
+++ b/src/usb/hw_at32f4.c
@@ -86,9 +86,9 @@ void usb_stall(uint8_t epnr)
     drv->stall(epnr);
 }
 
-void usb_clear_halt(uint8_t epnr)
+void usb_clear_stall(uint8_t epnr)
 {
-    drv->clear_halt(epnr);
+    drv->clear_stall(epnr);
 }
 
 void usb_configure_ep(uint8_t epnr, uint8_t type, uint32_t size)

--- a/src/usb/hw_at32f4.c
+++ b/src/usb/hw_at32f4.c
@@ -86,6 +86,11 @@ void usb_stall(uint8_t epnr)
     drv->stall(epnr);
 }
 
+void usb_clear_halt(uint8_t epnr)
+{
+    drv->clear_halt(epnr);
+}
+
 void usb_configure_ep(uint8_t epnr, uint8_t type, uint32_t size)
 {
     drv->configure_ep(epnr, type, size);

--- a/src/usb/hw_dwc_otg.c
+++ b/src/usb/hw_dwc_otg.c
@@ -240,11 +240,16 @@ static void dwc_otg_write(uint8_t epnr, const void *buf, uint32_t len)
 
 static void dwc_otg_stall(uint8_t epnr)
 {
-    otg_diep[epnr].ctl |= OTG_DIEPCTL_STALL;
-    otg_doep[epnr].ctl |= OTG_DOEPCTL_STALL;
+    bool_t in = !!(epnr & 0x80);
+    epnr &= 0x7f;
+    if (in) {
+        otg_diep[epnr].ctl |= OTG_DIEPCTL_STALL;
+    } else {
+        otg_doep[epnr].ctl |= OTG_DOEPCTL_STALL;
+    }
 }
 
-static void dwc_otg_clear_halt(uint8_t epnr)
+static void dwc_otg_clear_stall(uint8_t epnr)
 {
     bool_t in = !!(epnr & 0x80);
     epnr &= 0x7f;
@@ -490,7 +495,7 @@ const struct usb_driver dwc_otg = {
     .read = dwc_otg_read,
     .write = dwc_otg_write,
     .stall = dwc_otg_stall,
-    .clear_halt = dwc_otg_clear_halt
+    .clear_stall = dwc_otg_clear_stall
 };
 
 /*

--- a/src/usb/hw_dwc_otg.c
+++ b/src/usb/hw_dwc_otg.c
@@ -244,6 +244,19 @@ static void dwc_otg_stall(uint8_t epnr)
     otg_doep[epnr].ctl |= OTG_DOEPCTL_STALL;
 }
 
+static void dwc_otg_clear_halt(uint8_t epnr)
+{
+    bool_t in = !!(epnr & 0x80);
+    epnr &= 0x7f;
+    if (in) {
+        otg_diep[epnr].ctl &= ~OTG_DIEPCTL_STALL;
+        otg_diep[epnr].ctl |= OTG_DIEPCTL_SD0PID;
+    } else {
+        otg_doep[epnr].ctl &= ~OTG_DOEPCTL_STALL;
+        otg_doep[epnr].ctl |= OTG_DOEPCTL_SD0PID;
+    }
+}
+
 static void dwc_otg_configure_ep(uint8_t epnr, uint8_t type, uint32_t size)
 {
     int i;
@@ -476,7 +489,8 @@ const struct usb_driver dwc_otg = {
     .ep_tx_ready = dwc_otg_ep_tx_ready,
     .read = dwc_otg_read,
     .write = dwc_otg_write,
-    .stall = dwc_otg_stall
+    .stall = dwc_otg_stall,
+    .clear_halt = dwc_otg_clear_halt
 };
 
 /*

--- a/src/usb/hw_f1.c
+++ b/src/usb/hw_f1.c
@@ -59,9 +59,9 @@ void usb_stall(uint8_t epnr)
     usbd.stall(epnr);
 }
 
-void usb_clear_halt(uint8_t epnr)
+void usb_clear_stall(uint8_t epnr)
 {
-    usbd.clear_halt(epnr);
+    usbd.clear_stall(epnr);
 }
 
 void usb_configure_ep(uint8_t epnr, uint8_t type, uint32_t size)

--- a/src/usb/hw_f1.c
+++ b/src/usb/hw_f1.c
@@ -59,6 +59,11 @@ void usb_stall(uint8_t epnr)
     usbd.stall(epnr);
 }
 
+void usb_clear_halt(uint8_t epnr)
+{
+    usbd.clear_halt(epnr);
+}
+
 void usb_configure_ep(uint8_t epnr, uint8_t type, uint32_t size)
 {
     usbd.configure_ep(epnr, type, size);

--- a/src/usb/hw_f7.c
+++ b/src/usb/hw_f7.c
@@ -148,6 +148,11 @@ void usb_stall(uint8_t epnr)
     dwc_otg.stall(epnr);
 }
 
+void usb_clear_halt(uint8_t epnr)
+{
+    dwc_otg.clear_halt(epnr);
+}
+
 void usb_configure_ep(uint8_t epnr, uint8_t type, uint32_t size)
 {
     dwc_otg.configure_ep(epnr, type, size);

--- a/src/usb/hw_f7.c
+++ b/src/usb/hw_f7.c
@@ -148,9 +148,9 @@ void usb_stall(uint8_t epnr)
     dwc_otg.stall(epnr);
 }
 
-void usb_clear_halt(uint8_t epnr)
+void usb_clear_stall(uint8_t epnr)
 {
-    dwc_otg.clear_halt(epnr);
+    dwc_otg.clear_stall(epnr);
 }
 
 void usb_configure_ep(uint8_t epnr, uint8_t type, uint32_t size)

--- a/src/usb/hw_usbd.c
+++ b/src/usb/hw_usbd.c
@@ -182,30 +182,60 @@ static void usbd_write(uint8_t ep, const void *buf, uint32_t len)
     usb->epr[ep] = epr;
 }
 
-static void usbd_stall(uint8_t ep)
+static void usbd_stall(uint8_t epnr)
 {
-    uint16_t epr = usb->epr[ep];
-    epr &= 0x073f;
-    epr |= 0x8080;
-    epr ^= USB_EPR_STAT_TX(USB_STAT_STALL);
-    usb->epr[ep] = epr;
-}
+    bool_t in;
+    uint16_t epr;
 
-static void usbd_clear_halt(uint8_t epnr)
-{
-    bool_t in = !!(epnr & 0x80);
-    uint16_t epr, val;
+    in = !!(epnr & 0x80);
     epnr &= 0x7f;
     epr = usb->epr[epnr];
-    val = epr & 0x070f; /* preserve R/W: EA, EP_TYPE, EP_KIND */
-    val |= 0x8080;      /* preserve rc_w0: CTR_TX, CTR_RX */
-    /* STAT written as 0: no toggle, unchanged.
-     * Write current DTOG value to toggle it to 0 if set. */
-    if (in)
-        val |= epr & USB_EPR_DTOG_TX;
-    else
-        val |= epr & USB_EPR_DTOG_RX;
-    usb->epr[epnr] = val;
+
+    if (in) {
+        epr &= 0x073f;
+        epr ^= USB_EPR_STAT_TX(USB_STAT_STALL);
+    } else {
+        epr &= 0x370f;
+        epr ^= USB_EPR_STAT_RX(USB_STAT_STALL);
+    }
+
+    epr |= 0x8080; /* preserve rc_w0 fields */
+    usb->epr[epnr] = epr;
+}
+
+static void usbd_clear_stall(uint8_t epnr)
+{
+    bool_t in, dbl_buf;
+    uint16_t epr;
+    int new_status = USB_STAT_VALID;
+
+    in = !!(epnr & 0x80);
+    epnr &= 0x7f;
+    epr = usb->epr[epnr];
+    dbl_buf = !!(epr & USB_EPR_EP_KIND_DBL_BUF);
+
+    /* Clear data toggle and set status to VALID or NAK as appropriate. */
+    if (in) {
+        if (dbl_buf) {
+            epr ^= 0x4000; /* Set SW_BUF */
+        } else {
+            epr &= ~0x4000;
+            new_status = USB_STAT_NAK;
+        }
+        epr &= 0x477f; /* preserve rw & t, except tx toggle and status */
+        epr ^= USB_EPR_STAT_TX(new_status);
+    } else {
+        if (dbl_buf) {
+            epr |= 0x0040; /* Clear SW_BUF */
+        } else {
+            epr &= ~0x0040;
+        }
+        epr &= 0x774f; /* preserve rw & t, except rx toggle and status */
+        epr ^= USB_EPR_STAT_RX(new_status);
+    }
+
+    epr |= 0x8080; /* preserve rc_w0 fields */
+    usb->epr[epnr] = epr;
 }
 
 static void usbd_configure_ep(uint8_t ep, uint8_t type, uint32_t size)
@@ -411,7 +441,7 @@ const struct usb_driver usbd = {
     .read = usbd_read,
     .write = usbd_write,
     .stall = usbd_stall,
-    .clear_halt = usbd_clear_halt
+    .clear_stall = usbd_clear_stall
 };
 
 /*

--- a/src/usb/hw_usbd.c
+++ b/src/usb/hw_usbd.c
@@ -191,6 +191,23 @@ static void usbd_stall(uint8_t ep)
     usb->epr[ep] = epr;
 }
 
+static void usbd_clear_halt(uint8_t epnr)
+{
+    bool_t in = !!(epnr & 0x80);
+    uint16_t epr, val;
+    epnr &= 0x7f;
+    epr = usb->epr[epnr];
+    val = epr & 0x070f; /* preserve R/W: EA, EP_TYPE, EP_KIND */
+    val |= 0x8080;      /* preserve rc_w0: CTR_TX, CTR_RX */
+    /* STAT written as 0: no toggle, unchanged.
+     * Write current DTOG value to toggle it to 0 if set. */
+    if (in)
+        val |= epr & USB_EPR_DTOG_TX;
+    else
+        val |= epr & USB_EPR_DTOG_RX;
+    usb->epr[epnr] = val;
+}
+
 static void usbd_configure_ep(uint8_t ep, uint8_t type, uint32_t size)
 {
     static const uint8_t types[] = {
@@ -393,7 +410,8 @@ const struct usb_driver usbd = {
     .ep_tx_ready = usbd_ep_tx_ready,
     .read = usbd_read,
     .write = usbd_write,
-    .stall = usbd_stall
+    .stall = usbd_stall,
+    .clear_halt = usbd_clear_halt
 };
 
 /*

--- a/src/usb/hw_usbd_at32f4.c
+++ b/src/usb/hw_usbd_at32f4.c
@@ -230,37 +230,63 @@ static void usbd_stall(uint8_t epnr)
 
 static void usbd_clear_stall(uint8_t epnr)
 {
-    bool_t in, dbl_buf;
-    uint16_t epr;
-    int new_status = USB_STAT_VALID;
+    bool_t in;
+    struct ep *ep;
+    volatile struct usb_bufd *bd;
+    uint16_t old_epr, new_epr;
 
     in = !!(epnr & 0x80);
     epnr &= 0x7f;
-    epr = usb->epr[epnr];
-    dbl_buf = !!(epr & USB_EPR_EP_KIND_DBL_BUF);
+    ep = &eps[epnr];
+    bd = &usb_bufd[epnr];
 
-    /* Clear data toggle and set status to VALID or NAK as appropriate. */
-    if (in) {
-        if (dbl_buf) {
-            epr ^= 0x4000; /* Set SW_BUF */
+    old_epr = usb->epr[epnr];
+    new_epr = old_epr & 0x070f; /* preserve rw & t fields */
+
+    if (ep->is_dblbuf) {
+
+        /* Reset double-buffer ring and endpoint state to match
+         * usbd_configure_ep() initialisation. Buffer addresses
+         * (bd->addr_0/1) are not changed. */
+        uint32_t oldpri = IRQ_save(USB_IRQ_PRI);
+        ep->db.bufc = ep->db.bufp = ep->db.tx_hw_slots = 0;
+        if (in) {
+            bd->count_0 = bd->count_1 = 0;
+            /* TX: Clears SW_BUF. */
+            new_epr |= old_epr & 0x4000;
+            /* TX: Clears data toggle and sets status to VALID. */
+            new_epr |= (old_epr & 0x0070)
+                ^ USB_EPR_STAT_TX(USB_STAT_VALID);
+            ep->db.kick = TRUE;
         } else {
-            epr &= ~0x4000;
-            new_status = USB_STAT_NAK;
+            bd->count_0 = bd->count_1 = 0x8400; /* USB_FS_MPS */
+            /* RX: Sets SW_BUF. */
+            new_epr |= (old_epr & 0x0040) ^ 0x0040;
+            ep->db.kick = FALSE;
+            /* RX: Clears data toggle and sets status to VALID. */
+            new_epr |= (old_epr & 0x7000)
+                ^ USB_EPR_STAT_RX(USB_STAT_VALID);
         }
-        epr &= 0x477f; /* preserve rw & t, except tx toggle and status */
-        epr ^= USB_EPR_STAT_TX(new_status);
+        barrier();
+        usb->epr[epnr] = new_epr;
+        IRQ_restore(oldpri);
+
     } else {
-        if (dbl_buf) {
-            epr |= 0x0040; /* Clear SW_BUF */
-        } else {
-            epr &= ~0x0040;
-        }
-        epr &= 0x774f; /* preserve rw & t, except rx toggle and status */
-        epr ^= USB_EPR_STAT_RX(new_status);
-    }
 
-    epr |= 0x8080; /* preserve rc_w0 fields */
-    usb->epr[epnr] = epr;
+        /* Standard endpoint: clear data toggle, set status to NAK. */
+        if (in) {
+            new_epr |= old_epr & USB_EPR_DTOG_TX;
+            new_epr |= (old_epr & 0x0030)
+                ^ USB_EPR_STAT_TX(USB_STAT_NAK);
+        } else {
+            new_epr |= old_epr & USB_EPR_DTOG_RX;
+            new_epr |= (old_epr & 0x3000)
+                ^ USB_EPR_STAT_RX(USB_STAT_NAK);
+        }
+        new_epr |= 0x8080; /* preserve rc_w0 fields */
+        usb->epr[epnr] = new_epr;
+
+    }
 }
 
 static void usbd_configure_ep(uint8_t epnr, uint8_t type, uint32_t size)

--- a/src/usb/hw_usbd_at32f4.c
+++ b/src/usb/hw_usbd_at32f4.c
@@ -216,6 +216,62 @@ static void usbd_stall(uint8_t ep)
     usb->epr[ep] = epr;
 }
 
+static void usbd_clear_halt(uint8_t epnr)
+{
+    bool_t in = !!(epnr & 0x80);
+    struct ep *ep;
+    volatile struct usb_bufd *bd;
+    uint16_t old_epr, new_epr;
+    uint32_t oldpri;
+
+    epnr &= 0x7f;
+    ep = &eps[epnr];
+    bd = &usb_bufd[epnr];
+
+    old_epr = usb->epr[epnr];
+    new_epr = old_epr & 0x070f; /* preserve rw & t fields */
+
+    if (ep->is_dblbuf) {
+
+        /* Reset double-buffer ring and endpoint state to match
+         * usbd_configure_ep() initialisation. Buffer addresses
+         * (bd->addr_0/1) are not changed. */
+        oldpri = IRQ_save(USB_IRQ_PRI);
+        ep->db.bufc = ep->db.bufp = ep->db.tx_hw_slots = 0;
+        if (in) {
+            bd->count_0 = bd->count_1 = 0;
+            /* TX: Clears SW_BUF. */
+            new_epr |= old_epr & 0x4000;
+            /* TX: Clears data toggle and sets status to VALID. */
+            new_epr |= (old_epr & 0x0070)
+                ^ USB_EPR_STAT_TX(USB_STAT_VALID);
+            ep->db.kick = TRUE;
+        } else {
+            bd->count_0 = bd->count_1 = 0x8400; /* USB_FS_MPS */
+            /* RX: Sets SW_BUF. */
+            new_epr |= (old_epr & 0x0040) ^ 0x0040;
+            ep->db.kick = FALSE;
+            /* RX: Clears data toggle and sets status to VALID. */
+            new_epr |= (old_epr & 0x7000)
+                ^ USB_EPR_STAT_RX(USB_STAT_VALID);
+        }
+        barrier();
+        usb->epr[epnr] = new_epr;
+        IRQ_restore(oldpri);
+
+    } else {
+
+        /* Standard endpoint: clear data toggle only. */
+        new_epr |= 0x8080; /* preserve rc_w0 fields */
+        if (in)
+            new_epr |= old_epr & USB_EPR_DTOG_TX;
+        else
+            new_epr |= old_epr & USB_EPR_DTOG_RX;
+        usb->epr[epnr] = new_epr;
+
+    }
+}
+
 static void usbd_configure_ep(uint8_t epnr, uint8_t type, uint32_t size)
 {
     static const uint8_t types[] = {
@@ -526,7 +582,8 @@ const struct usb_driver usbd = {
     .ep_tx_ready = usbd_ep_tx_ready,
     .read = usbd_read,
     .write = usbd_write,
-    .stall = usbd_stall
+    .stall = usbd_stall,
+    .clear_halt = usbd_clear_halt
 };
 
 /*

--- a/src/usb/hw_usbd_at32f4.c
+++ b/src/usb/hw_usbd_at32f4.c
@@ -207,69 +207,60 @@ static void usbd_write(uint8_t epnr, const void *buf, uint32_t len)
     usb->epr[epnr] = epr;
 }
 
-static void usbd_stall(uint8_t ep)
+static void usbd_stall(uint8_t epnr)
 {
-    uint16_t epr = usb->epr[ep];
-    epr &= 0x073f;
-    epr |= 0x8080;
-    epr ^= USB_EPR_STAT_TX(USB_STAT_STALL);
-    usb->epr[ep] = epr;
+    bool_t in;
+    uint16_t epr;
+
+    in = !!(epnr & 0x80);
+    epnr &= 0x7f;
+    epr = usb->epr[epnr];
+    epr |= 0x8080; /* preserve rc_w0 fields */
+
+    if (in) {
+        epr &= 0x073f;
+        epr ^= USB_EPR_STAT_TX(USB_STAT_STALL);
+    } else {
+        epr &= 0x370f;
+        epr ^= USB_EPR_STAT_RX(USB_STAT_STALL);
+    }
+
+    usb->epr[epnr] = epr;
 }
 
-static void usbd_clear_halt(uint8_t epnr)
+static void usbd_clear_stall(uint8_t epnr)
 {
-    bool_t in = !!(epnr & 0x80);
-    struct ep *ep;
-    volatile struct usb_bufd *bd;
-    uint16_t old_epr, new_epr;
-    uint32_t oldpri;
+    bool_t in, dbl_buf;
+    uint16_t epr;
+    int new_status = USB_STAT_VALID;
 
+    in = !!(epnr & 0x80);
     epnr &= 0x7f;
-    ep = &eps[epnr];
-    bd = &usb_bufd[epnr];
+    epr = usb->epr[epnr];
+    dbl_buf = !!(epr & USB_EPR_EP_KIND_DBL_BUF);
 
-    old_epr = usb->epr[epnr];
-    new_epr = old_epr & 0x070f; /* preserve rw & t fields */
-
-    if (ep->is_dblbuf) {
-
-        /* Reset double-buffer ring and endpoint state to match
-         * usbd_configure_ep() initialisation. Buffer addresses
-         * (bd->addr_0/1) are not changed. */
-        oldpri = IRQ_save(USB_IRQ_PRI);
-        ep->db.bufc = ep->db.bufp = ep->db.tx_hw_slots = 0;
-        if (in) {
-            bd->count_0 = bd->count_1 = 0;
-            /* TX: Clears SW_BUF. */
-            new_epr |= old_epr & 0x4000;
-            /* TX: Clears data toggle and sets status to VALID. */
-            new_epr |= (old_epr & 0x0070)
-                ^ USB_EPR_STAT_TX(USB_STAT_VALID);
-            ep->db.kick = TRUE;
+    /* Clear data toggle and set status to VALID or NAK as appropriate. */
+    if (in) {
+        if (dbl_buf) {
+            epr ^= 0x4000; /* Set SW_BUF */
         } else {
-            bd->count_0 = bd->count_1 = 0x8400; /* USB_FS_MPS */
-            /* RX: Sets SW_BUF. */
-            new_epr |= (old_epr & 0x0040) ^ 0x0040;
-            ep->db.kick = FALSE;
-            /* RX: Clears data toggle and sets status to VALID. */
-            new_epr |= (old_epr & 0x7000)
-                ^ USB_EPR_STAT_RX(USB_STAT_VALID);
+            epr &= ~0x4000;
+            new_status = USB_STAT_NAK;
         }
-        barrier();
-        usb->epr[epnr] = new_epr;
-        IRQ_restore(oldpri);
-
+        epr &= 0x477f; /* preserve rw & t, except tx toggle and status */
+        epr ^= USB_EPR_STAT_TX(new_status);
     } else {
-
-        /* Standard endpoint: clear data toggle only. */
-        new_epr |= 0x8080; /* preserve rc_w0 fields */
-        if (in)
-            new_epr |= old_epr & USB_EPR_DTOG_TX;
-        else
-            new_epr |= old_epr & USB_EPR_DTOG_RX;
-        usb->epr[epnr] = new_epr;
-
+        if (dbl_buf) {
+            epr |= 0x0040; /* Clear SW_BUF */
+        } else {
+            epr &= ~0x0040;
+        }
+        epr &= 0x774f; /* preserve rw & t, except rx toggle and status */
+        epr ^= USB_EPR_STAT_RX(new_status);
     }
+
+    epr |= 0x8080; /* preserve rc_w0 fields */
+    usb->epr[epnr] = epr;
 }
 
 static void usbd_configure_ep(uint8_t epnr, uint8_t type, uint32_t size)
@@ -583,7 +574,7 @@ const struct usb_driver usbd = {
     .read = usbd_read,
     .write = usbd_write,
     .stall = usbd_stall,
-    .clear_halt = usbd_clear_halt
+    .clear_stall = usbd_clear_stall
 };
 
 /*


### PR DESCRIPTION
The current firmware hangs after the first gw run, because umodem(9) sends a CLEAR_FEATURE.  I think this is an appropriate fix.